### PR TITLE
Remove unused host variable

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,7 +2,7 @@ import React from "react"
 
 exports.onRenderBody = ({ setPostBodyComponents }, pluginOptions) => {
   if (process.env.NODE_ENV === `production`) {
-    const {id, sv, host} = pluginOptions
+    const {id, sv} = pluginOptions
     return setPostBodyComponents([
       <script
         key={`gatsby-plugin-hotjar`}


### PR DESCRIPTION
The host was removed from the package, but this was left in the code. We can now get rid of this unused variable.